### PR TITLE
Manually reload plugins

### DIFF
--- a/Daf.Core.VSCode/package.json
+++ b/Daf.Core.VSCode/package.json
@@ -21,6 +21,7 @@
 		"onCommand:workbench.action.tasks.runTask",
 		"onCommand:daf.createProjectFile",
 		"onCommand:createUserFile",
+		"onCommand:reloadPlugins",
 		"onLanguage:ion"
 	],
 	"main": "./out/extension.js",
@@ -33,6 +34,10 @@
 			{
 				"command": "daf.createUserFile",
 				"title": "Create a .dafproj.user file for overriding build parameters."
+			},
+			{
+				"command": "daf.reloadPlugins",
+				"title": "Reload Daf plugins"
 			}
 		],
 		"configuration": {

--- a/Daf.Core.VSCode/src/extension.ts
+++ b/Daf.Core.VSCode/src/extension.ts
@@ -240,9 +240,12 @@ async function createUserFile(): Promise<void>
 
 async function reloadPlugins(): Promise<void>
 {
-	if (lspClient != undefined){
+	if (lspClient != undefined)
+	{
 		lspClient.sendRequest('daf/reloadplugins');
-	} else {
+	}
+	else
+	{
 		vscode.window.showInformationMessage('Cannot reload Daf plugins, language server has not been initiated.');
 	}
 }

--- a/Daf.Core.VSCode/src/extension.ts
+++ b/Daf.Core.VSCode/src/extension.ts
@@ -39,6 +39,8 @@ var userFile =
 
 let taskProvider: vscode.Disposable | undefined;
 
+let lspClient: LanguageClient | undefined;
+
 export function activate(_context: vscode.ExtensionContext): void
 {
 	let workspaceRoot = vscode.workspace.workspaceFolders![0];
@@ -47,7 +49,7 @@ export function activate(_context: vscode.ExtensionContext): void
 		// Abort if we don't have a workspace.
 		return;
 	}
-
+	
 	let projectFileDisposable = vscode.commands.registerCommand('daf.createProjectFile', () =>
 	{
 		createProjectFile();
@@ -65,6 +67,16 @@ export function activate(_context: vscode.ExtensionContext): void
 	});
 
 	_context.subscriptions.push(userFileDisposable);
+	
+
+	let reloadPluginsDisposable = vscode.commands.registerCommand('daf.reloadPlugins', () =>
+	{
+		reloadPlugins();
+
+		vscode.window.showInformationMessage('Reloaded Daf plugins.');
+	});
+
+	_context.subscriptions.push(reloadPluginsDisposable);
 
 	let dafPromise: Thenable<vscode.Task[]> | undefined = undefined;
 	
@@ -84,7 +96,7 @@ export function activate(_context: vscode.ExtensionContext): void
 			return undefined;
 		}
 	});
-	
+
 	//Language server client 
 	loadLanguageServer(_context, workspaceRoot);
 }
@@ -132,6 +144,8 @@ async function loadLanguageServer(_context: vscode.ExtensionContext, workspaceRo
 	const client: LanguageClient = new LanguageClient('LSP', 'Daf Core Language Server', serverOptions, clientOptions);
 	client.trace = Trace.Verbose;
 	let disposable = client.start();
+
+	lspClient = client;
 
 	_context.subscriptions.push(disposable);
 }
@@ -222,6 +236,15 @@ async function createUserFile(): Promise<void>
 			}
 		});
 	});
+}
+
+async function reloadPlugins(): Promise<void>
+{
+	if (lspClient != undefined){
+		lspClient.sendRequest('daf/reloadplugins');
+	} else {
+		vscode.window.showInformationMessage('Cannot reload Daf plugins, language server has not been initiated.');
+	}
 }
 
 export function deactivate(): void

--- a/Daf.Core.VSCode/src/extension.ts
+++ b/Daf.Core.VSCode/src/extension.ts
@@ -49,7 +49,7 @@ export function activate(_context: vscode.ExtensionContext): void
 		// Abort if we don't have a workspace.
 		return;
 	}
-	
+
 	let projectFileDisposable = vscode.commands.registerCommand('daf.createProjectFile', () =>
 	{
 		createProjectFile();

--- a/LanguageServer/Daf.Core.LanguageServer.Tests/UnitTests/IonDocument_GetPositionalContext.cs
+++ b/LanguageServer/Daf.Core.LanguageServer.Tests/UnitTests/IonDocument_GetPositionalContext.cs
@@ -88,14 +88,14 @@ namespace Daf.Core.LanguageServerTests.UnitTests
 		}
 
 		[Fact]
-		internal void CursorAt_NodeAtFirstLine_ReturnsUnknown()
+		internal void CursorAt_NodeAtFirstLine_ReturnsAtNodename()
 		{
 			IonDocument document = new("RootNode:", new Uri(Constants.DummyRootNodeFileUri));
 			int cursorPosition = 5; //At the root node name
 
 			DocumentContext dcActual = document.GetPositionalContext(cursorPosition);
 
-			Assert.Equal(PositionalContext.Unknown, dcActual.Context);
+			Assert.Equal(PositionalContext.AtNodeName, dcActual.Context);
 		}
 	}
 }

--- a/LanguageServer/Daf.Core.LanguageServer/Handlers/IReloadPluginHandler.cs
+++ b/LanguageServer/Daf.Core.LanguageServer/Handlers/IReloadPluginHandler.cs
@@ -1,0 +1,19 @@
+﻿// SPDX-License-Identifier: MIT
+// Copyright © 2021 Oscar Björhn, Petter Löfgren and contributors
+
+using System.Threading.Tasks;
+using MediatR;
+using OmniSharp.Extensions.JsonRpc;
+
+namespace Daf.Core.LanguageServer.Handlers
+{
+	public class ReloadPluginRequest : IRequest
+	{
+	}
+
+	[Method("daf/reloadplugins", Direction.ClientToServer)]
+	[Parallel]
+	internal interface IReloadPluginHandler : IJsonRpcHandler, IRequestHandler<ReloadPluginRequest>
+	{
+	}
+}

--- a/LanguageServer/Daf.Core.LanguageServer/Handlers/ReloadPluginHandler.cs
+++ b/LanguageServer/Daf.Core.LanguageServer/Handlers/ReloadPluginHandler.cs
@@ -1,0 +1,45 @@
+﻿// SPDX-License-Identifier: MIT
+// Copyright © 2021 Oscar Björhn, Petter Löfgren and contributors
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Daf.Core.LanguageServer.Services;
+using Daf.Core.LanguageServer.Status;
+using MediatR;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using OmniSharp.Extensions.LanguageServer.Protocol.Window;
+
+namespace Daf.Core.LanguageServer.Handlers
+{
+	public class ReloadPluginHandler : IReloadPluginHandler
+	{
+		private readonly ILanguageServerFacade _router;
+		private readonly ReloadPluginService _reloadPluginService;
+
+		public ReloadPluginHandler(ILanguageServerFacade router, ReloadPluginService reloadPluginService)
+		{
+			_reloadPluginService = reloadPluginService;
+			_router = router;
+		}
+
+		public Task<Unit> Handle(ReloadPluginRequest request, CancellationToken cancellationToken)
+		{
+			List<PluginParsingStatus> statuses = _reloadPluginService.ReloadPlugins();
+
+			foreach (PluginParsingStatus status in statuses)
+			{
+				if (status.Status == OperationStatus.Error)
+				{
+					_router.Window.LogError(status.Message);
+				}
+				else if (status.Status == OperationStatus.Warning)
+				{
+					_router.Window.LogWarning(status.Message);
+				}
+			}
+
+			return Unit.Task;
+		}
+	}
+}

--- a/LanguageServer/Daf.Core.LanguageServer/Model/LanguageServerPluginManager.cs
+++ b/LanguageServer/Daf.Core.LanguageServer/Model/LanguageServerPluginManager.cs
@@ -324,8 +324,10 @@ namespace Daf.Core.LanguageServer.Model
 			return found;
 		}
 
-		public List<PluginParsingStatus> LoadAssemblies(string localFolder)
+		public void LoadAssemblies(string localFolder)
 		{
+			PluginParsingStatuses.Clear();
+
 			List<PluginParsingStatus> statuses = new();
 
 			List<string> nugetPluginPaths = GetNugetPlugins();
@@ -362,6 +364,13 @@ namespace Daf.Core.LanguageServer.Model
 					try
 					{
 						PluginAssembly pa = new(Assembly.LoadFile(file));
+
+						//Remove the plugin if it has been added since earlier to enable reload of other versions of the plugin
+						if (Assemblies.ContainsKey(pa.RootNodeNameFull))
+						{
+							Assemblies.Remove(pa.RootNodeNameFull);
+						}
+
 						Assemblies.Add(pa.RootNodeNameFull, pa);
 
 						string docFile = Path.ChangeExtension(file, ".xml");
@@ -393,7 +402,7 @@ namespace Daf.Core.LanguageServer.Model
 				}
 			}
 
-			return statuses;
+			PluginParsingStatuses.AddRange(statuses);
 		}
 
 		private List<string> GetNugetPlugins()

--- a/LanguageServer/Daf.Core.LanguageServer/Program.cs
+++ b/LanguageServer/Daf.Core.LanguageServer/Program.cs
@@ -10,9 +10,7 @@ using Daf.Core.LanguageServer.Document;
 using Daf.Core.LanguageServer.Handlers;
 using Daf.Core.LanguageServer.Model;
 using Daf.Core.LanguageServer.Services;
-using Daf.Core.LanguageServer.Status;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -22,6 +20,8 @@ namespace Daf.Core.LanguageServer
 	{
 		public static async Task Main(string[] args)
 		{
+			System.Diagnostics.Debugger.Launch();
+
 			Parser.Default.ParseArguments<IonLanguageServerOptions>(args).WithParsed(options => SetProperties(options));
 
 			await StartUpAsync();
@@ -41,6 +41,7 @@ namespace Daf.Core.LanguageServer
 			lsOptions.WithHandler<IonHoverHandler>();
 			lsOptions.WithHandler<IonCompletionHandler>();
 			lsOptions.WithHandler<IonLinkHandler>();
+			lsOptions.WithHandler<ReloadPluginHandler>();
 			ILanguageServer ls = await OmniSharp.Extensions.LanguageServer.Server.LanguageServer.From(lsOptions);
 
 			await ls.WaitForExit;
@@ -56,14 +57,13 @@ namespace Daf.Core.LanguageServer
 		private static void ConfigureServices(IServiceCollection services)
 		{
 			LanguageServerPluginManager pm = new();
-			List<PluginParsingStatus> parsingStatuses = pm.LoadAssemblies(Properties.Instance.PluginFolder);
-			pm.PluginParsingStatuses.AddRange(parsingStatuses);
+			pm.LoadAssemblies(Properties.Instance.PluginFolder);
 
 			services.AddSingleton<IonDocumentManager>();
 			services.AddSingleton(m => pm);
 			services.AddSingleton<CompletionService>();
 			services.AddSingleton<HoverService>();
+			services.AddSingleton<ReloadPluginService>();
 		}
-
 	}
 }

--- a/LanguageServer/Daf.Core.LanguageServer/Program.cs
+++ b/LanguageServer/Daf.Core.LanguageServer/Program.cs
@@ -20,8 +20,6 @@ namespace Daf.Core.LanguageServer
 	{
 		public static async Task Main(string[] args)
 		{
-			System.Diagnostics.Debugger.Launch();
-
 			Parser.Default.ParseArguments<IonLanguageServerOptions>(args).WithParsed(options => SetProperties(options));
 
 			await StartUpAsync();

--- a/LanguageServer/Daf.Core.LanguageServer/Services/ReloadPluginService.cs
+++ b/LanguageServer/Daf.Core.LanguageServer/Services/ReloadPluginService.cs
@@ -1,0 +1,25 @@
+﻿// SPDX-License-Identifier: MIT
+// Copyright © 2021 Oscar Björhn, Petter Löfgren and contributors
+
+using System.Collections.Generic;
+using Daf.Core.LanguageServer.Model;
+using Daf.Core.LanguageServer.Status;
+
+namespace Daf.Core.LanguageServer.Services
+{
+	public class ReloadPluginService
+	{
+		private readonly LanguageServerPluginManager pluginManager;
+
+		public ReloadPluginService(LanguageServerPluginManager manager)
+		{
+			pluginManager = manager;
+		}
+
+		public List<PluginParsingStatus> ReloadPlugins()
+		{
+			pluginManager.LoadAssemblies(Properties.Instance.PluginFolder);
+			return pluginManager.PluginParsingStatuses;
+		}
+	}
+}

--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ Create new Daf project after having installed the extension:
   ```
   <ItemGroup>
     <PackageReference Include="Daf.Core.Ssis" Version="*" />
-  <ItemGroup>
+  </ItemGroup>
   ```
+* Build the project to download/restore the plugin from nuget.
 * Add a new root file with extension .daf. The first line in this file must contain three dashes (---) to indicate that it is the root file of the solution.
+* Run command  _Reload Daf plugins_ from the command pallete to enable auto completion (only required after adding new plugins or plugin versions).
 * Start coding:
   ![demo](https://user-images.githubusercontent.com/1073539/112722549-93613b80-8f0a-11eb-9495-2786007df9ff.gif)
 * Build the project (Ctrl+Shift+B) and select an appropiate build action, e.g. _Build Dev (Full)_.
@@ -39,4 +41,5 @@ Also see the sample projects in this repository.
 
 ## Links
 [Daf organization](https://github.com/data-automation-framework)
+
 [Documentation](https://data-automation-framework.com)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Create new Daf project after having installed the extension:
 * Add a new root file with extension .daf. The first line in this file must contain three dashes (---) to indicate that it is the root file of the solution.
 * Run command  _Reload Daf plugins_ from the command pallete to enable auto completion (only required after adding new plugins or plugin versions).
 * Start coding:
-  ![demo](https://user-images.githubusercontent.com/1073539/112722549-93613b80-8f0a-11eb-9495-2786007df9ff.gif)
+  ![demo2](https://user-images.githubusercontent.com/1073539/116812909-865eea00-ab51-11eb-8a8b-edf29592f37b.gif)
 * Build the project (Ctrl+Shift+B) and select an appropiate build action, e.g. _Build Dev (Full)_.
 * For the standard plugins, the output is generated in the underlying bin folder.
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Create new Daf project after having installed the extension:
 * Add a new root file with extension .daf. The first line in this file must contain three dashes (---) to indicate that it is the root file of the solution.
 * Run command  _Reload Daf plugins_ from the command pallete to enable auto completion (only required after adding new plugins or plugin versions).
 * Start coding:
+
   ![demo2](https://user-images.githubusercontent.com/1073539/116812909-865eea00-ab51-11eb-8a8b-edf29592f37b.gif)
 * Build the project (Ctrl+Shift+B) and select an appropiate build action, e.g. _Build Dev (Full)_.
 * For the standard plugins, the output is generated in the underlying bin folder.

--- a/Samples/Ion/Ion/Ion.dafproj
+++ b/Samples/Ion/Ion/Ion.dafproj
@@ -18,6 +18,7 @@
 		<sqlFile Include="**\*.sql" Exclude="$(OutputPath)\**\*.sql" />
 	</ItemGroup>
 	<ItemGroup>
+		<PackageReference Include="Daf.Core.Sql" Version="0.0.4" />
 		<PackageReference Include="Daf.Core.Ssis" Version="0.0.5" />
 	</ItemGroup>
 	<Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />

--- a/Samples/Ion/Ion/Ion.dafproj
+++ b/Samples/Ion/Ion/Ion.dafproj
@@ -17,6 +17,9 @@
 		<csCompile Include="**\*.cs" />
 		<sqlFile Include="**\*.sql" Exclude="$(OutputPath)\**\*.sql" />
 	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Daf.Core.Ssis" Version="0.0.5" />
+	</ItemGroup>
 	<Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 	<Import Project="$(DafCoreRootPath)Daf.Core.targets" />
 </Project>

--- a/Samples/Ion/Ion/includes/SsisInclude.daf
+++ b/Samples/Ion/Ion/includes/SsisInclude.daf
@@ -1,4 +1,26 @@
+<# int counter = 0; #>
 SsisProjects: 
-	SsisProject: Name="SsisProject"
+	SsisProject: Name="SsisProject" TargetSqlServerVersion=SqlServer2019 ProtectionLevel=DontSaveSensitive Password=""
+		Connections: 
+			FlatFileConnection: Name="FileConnection" ConnectionString=""
 		Packages: 
-			Package: Name="Package1"
+<# for (int i = 1; i <= 4; i++) { #>
+			Package: Name="Package_<#=i#>"
+				Variables: 
+					Variable: Name="Counter" DataType="Int32" Value="<#=counter#>"
+					Variable: Name="RowCounter" DataType="Int32" Value=0
+				Tasks: 
+					Expression: Name="Increment counter" ExpressionValue="@Counter = @Counter + 1"
+					SequenceContainer: Name="Container" 
+						PrecedenceConstraints: 
+							Inputs: 
+								InputPath: OutputPathName="Increment counter"
+						Tasks: 
+							DataFlow: Name="Data flow"
+								Components: 
+									FlatFileSource: Name="Flat file source" ConnectionName="FileConnection" 
+										FlatFileSourceColumns: 
+											DataFlowColumnMapping: SourceColumn="ID" TargetColumn="ID" 
+									RowCount: Name="Count" VariableName="RowCounter" 
+										DataFlowInputPath: OutputPathName="Flat file source"
+<# } #>


### PR DESCRIPTION
* Allow users to manually reload of plugins in the language server via a new command in the VSCode client, for example if changing the version of a plugin.
* Expanded and corrected sample project.
* Fixed bug in language server that enabled Ion lookups within T4 tags if they start on first column.